### PR TITLE
ライブラリ Apache Commons Lang　3.14.0 の追加

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,9 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	// Apache Commons Lang(便利機能・ユーティリティ)
+	implementation 'org.apache.commons:commons-lang3:3.14.0'
+
 	providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/raisetech/StudentManagement/StudentManagementApplication.java
+++ b/src/main/java/raisetech/StudentManagement/StudentManagementApplication.java
@@ -1,5 +1,6 @@
 package raisetech.StudentManagement;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,12 +10,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class StudentManagementApplication {
 
+  String word = "RaiseTech";
+
   public static void main(String[] args) {
     SpringApplication.run(StudentManagementApplication.class, args);
   }
 
-  @GetMapping("/hello")
-  public String hello() {
-    return "Hello World!";
+  @GetMapping("/judgeWord")
+  public String getJudgeWord() {
+    if (StringUtils.isEmpty(word)) {
+      return "空白の文字列です";
+    } else {
+      return word;
+    }
   }
+
 }


### PR DESCRIPTION
## **課題内容**
ApacheCommonsLangをbuild.gradleのdependenciesに追加し、ApacheCommonsLangが使用できるようになっているか確認をする。

## **実装内容**
**mainクラス**
・ApacheCommonsLangのStringUtils.isEmptyを使用して、文字列wordが空白かどうか判定を行う。


