### PR TITLE
受講コース情報の更新処理の実装

### DIFF
--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -59,15 +59,17 @@ public class StudentController {
   //生徒情報の変更処理画面への遷移
   @GetMapping("/editStudent")
   public String editStudent(Model model, @RequestParam String studentId) {
+    //登録データをオブジェクトに格納
     Student student = service.searchStudent(studentId);
     List<StudentsCourses> studentsCourses = service.studentsCourses(studentId);
     List<Course> courses = service.searchCourseList();
+    //データの整形
     List<CourseDetail> courseDetails = converter.courseDetails(studentsCourses, courses);
-    StudentDetail studentDetail = new StudentDetail();
-    studentDetail.setStudent(student);
-    studentDetail.setCourseDetail(courseDetails);
+    StudentDetail studentDetail = new StudentDetail(student, courseDetails);
+    //モデルへ紐づけ
     model.addAttribute("studentDetail", studentDetail);
     model.addAttribute("courses", courses);
+    //テンプレートファイルへリターン
     return "updateStudent";
   }
 

--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -60,7 +60,14 @@ public class StudentController {
   @GetMapping("/editStudent")
   public String editStudent(Model model, @RequestParam String studentId) {
     Student student = service.searchStudent(studentId);
-    model.addAttribute("student", student);
+    List<StudentsCourses> studentsCourses = service.studentsCourses(studentId);
+    List<Course> courses = service.searchCourseList();
+    List<CourseDetail> courseDetails = converter.courseDetails(studentsCourses, courses);
+    StudentDetail studentDetail = new StudentDetail();
+    studentDetail.setStudent(student);
+    studentDetail.setCourseDetail(courseDetails);
+    model.addAttribute("studentDetail", studentDetail);
+    model.addAttribute("courses", courses);
     return "updateStudent";
   }
 
@@ -76,11 +83,11 @@ public class StudentController {
 
   //生徒情報の更新処理
   @PostMapping("/updateStudent")
-  public String updateStudent(@ModelAttribute Student student, BindingResult result) {
+  public String updateStudent(@ModelAttribute StudentDetail studentDetail, BindingResult result) {
     if (result.hasErrors()) {
       return "updateStudent";
     }
-    service.updateStudent(student);
+    service.updateStudent(studentDetail);
     return "redirect:/studentList";
   }
 }

--- a/src/main/java/raisetech/StudentManagement/domein/StudentDetail.java
+++ b/src/main/java/raisetech/StudentManagement/domein/StudentDetail.java
@@ -12,4 +12,11 @@ public class StudentDetail {
   private Student student;
   private List<CourseDetail> courseDetail;
 
+  public StudentDetail() {
+  }
+
+  public StudentDetail(Student student, List<CourseDetail> courseDetails) {
+    this.student = student;
+    this.courseDetail = courseDetails;
+  }
 }

--- a/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
@@ -35,4 +35,7 @@ public interface StudentRepository {
       "UPDATE students SET name=#{name},furigana=#{furigana},nickname=#{nickname},email=#{email}"
           + ",address=#{address},age=#{age},gender=#{gender} WHERE student_id=#{studentId}")
   void updateStudent(Student student);
+
+  @Update("UPDATE students_courses SET course_id=#{courseId} WHERE id=#{id}")
+  void updateStudentCourses(StudentsCourses studentsCourses);
 }

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -2,6 +2,7 @@ package raisetech.StudentManagement.service;
 
 import java.sql.Date;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,6 +40,18 @@ public class StudentService {
         .findFirst().orElseGet(Student::new);
   }
 
+  //studentIdから受講コース情報の表示
+  public List<StudentsCourses> studentsCourses(String studentId) {
+    List<StudentsCourses> studentsCoursesList = repository.searchStudentsCourses();
+    List<StudentsCourses> studentsCourses = new ArrayList<>();
+    for (StudentsCourses studentsCourse : studentsCoursesList) {
+      if (studentsCourse.getStudentId().equals(studentId)) {
+        studentsCourses.add(studentsCourse);
+      }
+    }
+    return studentsCourses;
+  }
+
   //生徒コース情報のリスト表示
   public List<StudentsCourses> searchStudentCourseList(String courseId) {
     List<StudentsCourses> studentsCourseList = repository.searchStudentsCourses();
@@ -57,6 +70,7 @@ public class StudentService {
   }
 
   //生徒情報の新規追加
+  //@Transactional
   public void addStudent(StudentDetail studentDetail) {
     //生徒情報と受講コースの両方で使用するもの
     //生徒IDの決定
@@ -94,7 +108,14 @@ public class StudentService {
   }
 
   //生徒情報の変更
-  public void updateStudent(Student student) {
+  // @Transactional
+  public void updateStudent(StudentDetail studentDetail) {
+    Student student = studentDetail.getStudent();
     repository.updateStudent(student);
+    List<CourseDetail> courseDetails = studentDetail.getCourseDetail();
+    for (CourseDetail courseDetail : courseDetails) {
+      StudentsCourses studentsCourses = courseDetail.getStudentsCourses();
+      repository.updateStudentCourses(studentsCourses);
+    }
   }
 }

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import raisetech.StudentManagement.data.Course;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentsCourses;
@@ -20,7 +21,7 @@ public class StudentService {
   private final StudentRepository repository;
 
   @Autowired
-  private StudentService(StudentRepository repository) {
+  public StudentService(StudentRepository repository) {
     this.repository = repository;
   }
 
@@ -70,7 +71,7 @@ public class StudentService {
   }
 
   //生徒情報の新規追加
-  //@Transactional
+  @Transactional
   public void addStudent(StudentDetail studentDetail) {
     //生徒情報と受講コースの両方で使用するもの
     //生徒IDの決定
@@ -108,7 +109,7 @@ public class StudentService {
   }
 
   //生徒情報の変更
-  // @Transactional
+  @Transactional
   public void updateStudent(StudentDetail studentDetail) {
     Student student = studentDetail.getStudent();
     repository.updateStudent(student);

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -6,38 +6,51 @@
 </head>
 <body>
 <h1>受講生情報の編集</h1>
-<form th:action="@{/updateStudent}" th:object="${student}" method="post">
-  <input type="hidden" name="studentId" th:field="*{studentId}" th:value="${studentId}"/>
+<form th:action="@{/updateStudent}" th:object="${studentDetail}" method="post">
+  <input type="hidden" name="studentId" th:field="*{student.studentId}"/>
   <div>
     <label for="name">名前：</label>
-    <input type="text" id="name" th:field="*{name}" th:value="${name}" required/>
+    <input type="text" id="name" th:field="*{student.name}" required/>
   </div>
   <div>
     <label for="furigana">フリガナ：</label>
-    <input type="text" id="furigana" th:field="*{furigana}" th:value="${furigana}" required/>
+    <input type="text" id="furigana" th:field="*{student.furigana}" required/>
   </div>
   <div>
     <label for="nickname">ニックネーム：</label>
-    <input type="text" id="nickname" th:field="*{nickname}" th:value="${nickname}" required/>
+    <input type="text" id="nickname" th:field="*{student.nickname}" required/>
   </div>
   <div>
     <label for="email">メールアドレス：</label>
-    <input type="text" id="email" th:field="*{email}" th:value="${email}" required/>
+    <input type="text" id="email" th:field="*{student.email}" required/>
   </div>
   <div>
     <label for="address">地域：</label>
-    <input type="text" id="address" th:field="*{address}" th:value="${address}" required/>
+    <input type="text" id="address" th:field="*{student.address}" required/>
   </div>
   <div>
     <label for="age">年齢：</label>
-    <input type="text" id="age" th:field="*{age}" th:value="${age}" required/>
+    <input type="text" id="age" th:field="*{student.age}" required/>
   </div>
   <div>
     <label for="gender">性別：</label>
-    <select id="gender" th:field="*{gender}" th:value="${gender}" required>
+    <select id="gender" th:field="*{student.gender}" required>
       <option value="男性">男性</option>
       <option value="女性">女性</option>
       <option value="その他">その他</option>
+    </select>
+  </div>
+  <label for="courseId__${Stat.index}">コース</label>
+  <div th:each="courseDetail, Stat : ${studentDetail.courseDetail}">
+    <input type="hidden" name="id"
+           th:field="*{courseDetail[__${Stat.index}__].studentsCourses.id}"/>
+    <select id="courseId__${Stat.index}"
+            th:field="*{courseDetail[__${Stat.index}__].studentsCourses.courseId}"
+            required>
+      <option th:each="course : ${courses}"
+              th:value="${course.courseId}"
+              th:text="${course.course}">
+      </option>
     </select>
   </div>
   <div>


### PR DESCRIPTION
## 課題内容
1.更新処理の見直し
・受講コース情報の更新処理を実装しました。

2.論理削除の実装
※こちらは次回提出いたします。

## テーブル内容
### studentsテーブル
・構成
![image](https://github.com/user-attachments/assets/f57cb9e6-2ffe-43fc-b896-fa0ab6b7316b)
・データ
![image](https://github.com/user-attachments/assets/8163109e-a6a8-404c-9897-f035f6b4222f)
### students_coursesテーブル
・構成
![image](https://github.com/user-attachments/assets/69a78b4b-4df3-4baa-9ee7-7990874b0787)
・データ
![image](https://github.com/user-attachments/assets/2584f62b-ac64-493e-aea7-4753e1d8ac41)
### 
・構成
![image](https://github.com/user-attachments/assets/74297604-829e-41e1-b14f-9f5a4e3480e8)
・データ
![image](https://github.com/user-attachments/assets/40fd52cd-27e7-40cc-988a-1bf0532d056a)

## 実装内容
### コントローラー
#### editStudentメソッド
・studentIdをキーにしてstudent(生徒情報)、studentsCourses(受講コース情報)、courses(コース情報)を取得し
    上記3つのデータを格納したstudentDetailオブジェクトをテンプレートファイルへ渡す。
・courses(コース情報)のオブジェクトをテンプレートファイルへ渡す。(テンプレートファイル側で選択肢を表示するため)
#### updateStudentメソッド
・studentDetailオブジェクトの情報をテンプレートファイルから受け取る。
・サービスのupdateStudentメソッドに受け取った情報を渡して実行。
・リダイレクトを設定し生徒一覧へ遷移。
### リポジトリ
#### updateStudentCoursesメソッド
・studentsCourses(受講コース情報)をサービス側から受け取る。
・studentsCourses(受講コース情報)のidをキーにしてcourse_idの値をアップデートするSQL文の実行。
### サービス
#### studentsCoursesメソッド
・リポジトリ側からstudentsCourses(受講コース情報)を取得
・コントローラー側から受けとったstudentIdをキーにして一致するstudentsCourses(受講コース情報)を絞り込み
　コントローラー側に返す。
#### updateStudentメソッド
・studentDetailオブジェクトの情報を受け取る。
・studentsCourses(受講コース情報)をリポジトリのupdateStudentCoursesメソッドに渡す。
### テンプレートファイル
#### updateStudent.html 
・バインディングするオブジェクトを studentDetailに変更。それにともない、各<input>のth:fieldを修正。
・studentDetailオブジェクトのcourseDetail(受講コース情報＋コース情報)をリスト表示。
・coursesオブジェクトとバインディングして、<option>を作成。
## 実行結果
https://github.com/user-attachments/assets/61492b66-e020-46bf-a705-0da0fe99a6fc





