### PR TITLE
論理削除の実装

### DIFF
--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -34,12 +34,15 @@ public class StudentController {
   public String getStudentList(Model model, @RequestParam(defaultValue = "0") int minAge,
       @RequestParam(defaultValue = "130") int maxAge,
       @RequestParam(defaultValue = "") String courseId) {
+    //登録データをオブジェクトに格納
     List<Student> students = service.searchStudentList(minAge, maxAge);
     List<Course> courses = service.searchCourseList();
     List<StudentsCourses> studentsCourses = service.searchStudentCourseList(courseId);
     List<CourseDetail> courseDetails = converter.courseDetails(studentsCourses, courses);
+    //モデルへ紐づけ
     model.addAttribute("studentList",
         converter.studentDetails(students, courseDetails));
+    //テンプレートファイルへリターン
     return "studentList";
   }
 
@@ -90,6 +93,27 @@ public class StudentController {
       return "updateStudent";
     }
     service.updateStudent(studentDetail);
+    return "redirect:/studentList";
+  }
+
+  //生徒情報削除の確認画面への遷移
+  @PostMapping("/confirmDeletion")
+  public String confirmDeletion(Model model, @RequestParam String studentId) {
+    //登録データをオブジェクトに格納
+    Student student = service.searchStudent(studentId);
+    //モデルへの紐づけ
+    model.addAttribute("student", student);
+    //テンプレートファイルへリターン
+    return "confirmDeletion";
+  }
+
+  //生徒情報の削除処理
+  @PostMapping("/deleteStudent")
+  public String deleteStudent(@RequestParam String studentId) {
+    //studentIdから登録データをオブジェクトに格納
+    Student student = service.searchStudent(studentId);
+    //削除処理
+    service.deleteStudent(student);
     return "redirect:/studentList";
   }
 }

--- a/src/main/java/raisetech/StudentManagement/data/Student.java
+++ b/src/main/java/raisetech/StudentManagement/data/Student.java
@@ -17,4 +17,13 @@ public class Student {
   private String gender;
   private String remark;
   private boolean isDeleted;
+
+
+  public void delete() {
+    this.isDeleted = true;
+  }
+
+  public void undelete() {
+    this.isDeleted = false;
+  }
 }

--- a/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
@@ -38,4 +38,8 @@ public interface StudentRepository {
 
   @Update("UPDATE students_courses SET course_id=#{courseId} WHERE id=#{id}")
   void updateStudentCourses(StudentsCourses studentsCourses);
+
+  @Update(
+      "UPDATE students SET is_deleted =#{isDeleted} WHERE student_id=#{studentId}")
+  void deleteStudent(Student student);
 }

--- a/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
@@ -33,13 +33,10 @@ public interface StudentRepository {
 
   @Update(
       "UPDATE students SET name=#{name},furigana=#{furigana},nickname=#{nickname},email=#{email}"
-          + ",address=#{address},age=#{age},gender=#{gender} WHERE student_id=#{studentId}")
+          + ",address=#{address},age=#{age},gender=#{gender},is_deleted =#{isDeleted} WHERE student_id=#{studentId}")
   void updateStudent(Student student);
 
   @Update("UPDATE students_courses SET course_id=#{courseId} WHERE id=#{id}")
   void updateStudentCourses(StudentsCourses studentsCourses);
 
-  @Update(
-      "UPDATE students SET is_deleted =#{isDeleted} WHERE student_id=#{studentId}")
-  void deleteStudent(Student student);
 }

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -85,7 +85,7 @@ public class StudentService {
     //生徒IDのset
     student.setStudentId(studentId);
     //論理削除フラグをset
-    student.setDeleted(false);
+    student.undelete();
     //studentsテーブルに追加
     repository.insertStudent(student);
 
@@ -128,8 +128,8 @@ public class StudentService {
   @Transactional
   public void deleteStudent(Student student) {
     //削除フラグを立てる
-    student.setDeleted(true);
+    student.delete();
     //生徒情報削除の処理
-    repository.deleteStudent(student);
+    repository.updateStudent(student);
   }
 }

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -29,7 +29,8 @@ public class StudentService {
   public List<Student> searchStudentList(int minAge, int maxAge) {
     List<Student> studentList = repository.searchStudent();
     return studentList.stream()
-        .filter(student -> student.getAge() >= minAge && student.getAge() <= maxAge)
+        .filter(student -> student.getAge() >= minAge && student.getAge() <= maxAge
+            && !student.isDeleted())
         .collect(Collectors.toList());
   }
 
@@ -111,12 +112,24 @@ public class StudentService {
   //生徒情報の変更
   @Transactional
   public void updateStudent(StudentDetail studentDetail) {
+    //引数からを生徒情報をオブジェクトにセット
     Student student = studentDetail.getStudent();
+    //生徒情報の更新処理
     repository.updateStudent(student);
+    //引数から受講コース情報をオブジェクトにセット
     List<CourseDetail> courseDetails = studentDetail.getCourseDetail();
+    //受講コース情報の更新処理
     for (CourseDetail courseDetail : courseDetails) {
       StudentsCourses studentsCourses = courseDetail.getStudentsCourses();
       repository.updateStudentCourses(studentsCourses);
     }
+  }
+
+  @Transactional
+  public void deleteStudent(Student student) {
+    //削除フラグを立てる
+    student.setDeleted(true);
+    //生徒情報削除の処理
+    repository.deleteStudent(student);
   }
 }

--- a/src/main/resources/templates/confirmDeletion.html
+++ b/src/main/resources/templates/confirmDeletion.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/html" lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>受講生一覧</title>
+</head>
+<body>
+<h1>受講生情報の削除</h1>
+<p>受講生情報を削除してよろしいですか？</p>
+<table border="1">
+  <thead>
+  <tr>
+    <th>ID</th>
+    <th>名前</th>
+    <th>ふりがな</th>
+    <th>ニックネーム</th>
+    <th>メールアドレス</th>
+    <th>地域</th>
+    <th>年齢</th>
+    <th>性別</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr th:object="${student}">
+    <td th:text="*{studentId}">1</td>
+    <td th:text="*{name}">山田太郎</td>
+    <td th:text="*{furigana}">ヤマダタロウ</td>
+    <td th:text="*{nickname}">タロー</td>
+    <td th:text="*{email}">taro@example.com</td>
+    <td th:text="*{address}">東京</td>
+    <td th:text="*{age}">28</td>
+    <td th:text="*{gender}">男性</td>
+  </tbody>
+</table>
+<form th:action="@{/deleteStudent(studentId=${student.studentId})}" method="post">
+  <button type="submit">削除</button>
+</form>
+<form th:action="@{/studentList}" method="get">
+  <button type="submit">キャンセル</button>
+</form>
+</body>
+</html>

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -57,5 +57,11 @@
     <button type="submit">更新</button>
   </div>
 </form>
+<form th:action="@{/confirmDeletion(studentId=${studentDetail.student.studentId})}" method="post">
+  <button type="submit">削除</button>
+</form>
+<form th:action="@{/studentList}" method="get">
+  <button type="submit">一覧に戻る</button>
+</form>
 </body>
 </html>


### PR DESCRIPTION
## 課題内容
論理削除の実装

## テーブル内容
### studentsテーブル
・構成
![image](https://github.com/user-attachments/assets/f57cb9e6-2ffe-43fc-b896-fa0ab6b7316b)
・データ
![image](https://github.com/user-attachments/assets/8163109e-a6a8-404c-9897-f035f6b4222f)
### students_coursesテーブル
・構成
![image](https://github.com/user-attachments/assets/69a78b4b-4df3-4baa-9ee7-7990874b0787)
・データ
![image](https://github.com/user-attachments/assets/2584f62b-ac64-493e-aea7-4753e1d8ac41)
### coursesテーブル
・構成
![image](https://github.com/user-attachments/assets/74297604-829e-41e1-b14f-9f5a4e3480e8)
・データ
![image](https://github.com/user-attachments/assets/40fd52cd-27e7-40cc-988a-1bf0532d056a)

## 実装内容
### コントローラー
#### confirmDeletionメソッドの追記
・updateStudent.htmlからstudentIdを受け取る。
・受け取ったstudentIdから生徒情報を取得しモデルへ紐づけ。
・削除する生徒情報の確認画面への遷移。
#### deleteStudentメソッドの追記
・confirmDeletion.htmlからstudentIdを受け取る
・受け取ったstudentIdから生徒情報を取得。
・studentオブジェクトをサービス側へ渡す。
### リポジトリ
#### deleteStudentメソッドの追記
・サービス側からstudentオブジェクトを受け取る
・studentIdの一致するレコードのis_deletedの値を変更
### サービス
#### searchStudentListメソッドの記述変更
・studentオブジェクトのisDeletedフィールドがtrueのものを除外
#### deleteStudentメソッドの追記
・studentオブジェクトを受け取り削除フラグを立てる。
### テンプレートファイル
#### confirmDeletion.htmlの追加 
・updateStudent.htmlの削除ボタンから遷移。
・削除する生徒情報の表示
・削除処理を実行するか確認を行う。
・キャンセルボタンをクリックすると生徒情報一覧画面へ遷移。
#### updateStudent.htmlの記述変更
・削除ボタンの追加。クリックでconfirmDeletion.htmlへ遷移。
・一覧へ戻るボタンの追加。 
## 実行結果

https://github.com/user-attachments/assets/d53f2d4d-f872-482e-bde2-8d837180e911




